### PR TITLE
Codes/Commands Highlighted

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,28 +7,29 @@ Learn more docker compose <a href="https://docs.docker.com/compose/overview/" ta
 ## PLayground
 
 1. Clone this repository
-    
+```
     git clone git@github.com:fuadajip/dockercompose-mysql-phpmyadmin.git
+```
 
 2. Change to directory
-
+```shell
     cd dockercompose-mysql-phpmyadmin
-
+```
 3. Up the compose
-
+```
     docker-compose up -d
-
+```
 4. Access phpmyadmin
-
+```
     your_ip:8183
     Server: mysql
     Username: root/user
     Password: root/user
-
+```
 5. Access mysql on terminal
-
+```
     docker exec -it mysql_container_name mysql -u root -p
-
+```
 ## Docker phpmyadmin ENV
 <table>
 <tr>


### PR DESCRIPTION
Markdown file has format for codes and syntax highlighting.

+ Inline codes

``Inline `code` has `back-ticks around` it.``

Output:
Inline `code` has `back-ticks around` it.

+ Block of Codes
```` 
```javascript
var s = "JavaScript syntax highlighting";
alert(s);
```
```python
s = "Python syntax highlighting"
print s
```
```
No language indicated, so no syntax highlighting. 
But let's throw in a <b>tag</b>.
```
````

Output:
```javascript
var s = "JavaScript syntax highlighting";
alert(s);
```
```python
s = "Python syntax highlighting"
print s
``` 
```
No language indicated, so no syntax highlighting. 
But let's throw in a <b>tag</b>.
```



[Here](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) some stuff you can do in markdown file.